### PR TITLE
Remove compiled executable and add build artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ dist-ssr
 
 .env
 workdir
+
+# Build artifacts
+backend/bin/
+build/backend

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,4 @@ dist-ssr
 .env
 workdir
 
-# Build artifacts
 backend/bin/
-build/backend


### PR DESCRIPTION
Removes the compiled backend executable from the repository and updates .gitignore to prevent future commits of build artifacts.

Fixes #13

Generated with [Claude Code](https://claude.ai/code)