### PR TITLE
Add WebSocket ping keepalive functionality

### DIFF
--- a/backend/websocket.go
+++ b/backend/websocket.go
@@ -89,6 +89,11 @@ func NewWebSocketHandler(db *DatabaseClient, supabaseCli *supabase.Client, s3Cli
 func (ws *WebSocketHandler) Handle() {
 	var data WebSocketData
 
+	// Start ping routine to keep connection alive
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go ws.pingRoutine(ctx)
+
 	for {
 		messageType, message, err := ws.conn.ReadMessage()
 		if err != nil {
@@ -370,6 +375,23 @@ func (ws *WebSocketHandler) sendMachineProject(machineID int) {
 	}
 
 	ws.conn.WriteMessage(websocket.BinaryMessage, protocol.S2MInitAssets(urls[0], hashes[0], urls[1:], hashes[1:]))
+}
+
+func (ws *WebSocketHandler) pingRoutine(ctx context.Context) {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := ws.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				log.Printf("WebSocket ping error: %v", err)
+				return
+			}
+		}
+	}
 }
 
 func (ws *WebSocketHandler) verifySignature(id, publicKeyPem string, signature []byte) bool {

--- a/backend/websocket.go
+++ b/backend/websocket.go
@@ -89,7 +89,6 @@ func NewWebSocketHandler(db *DatabaseClient, supabaseCli *supabase.Client, s3Cli
 func (ws *WebSocketHandler) Handle() {
 	var data WebSocketData
 
-	// Start ping routine to keep connection alive
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go ws.pingRoutine(ctx)


### PR DESCRIPTION
Implements server-side ping mechanism that sends ping frames every 30 seconds to prevent connection timeouts in production environments with 60s read timeouts.

The browser WebSocket API automatically handles pong responses, so no client-side changes are needed.

Resolves #21